### PR TITLE
Change install step to use correct name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The program uses the [GitHub API](https://developer.github.com/) to discover rep
 # Installation
 
 1. Install [Node.js](http://nodejs.org/)
-2. Run `npm install -g github-install`
+2. Run `npm install -g github-backup`
 
 # Usage
 


### PR DESCRIPTION
The original documentation had "github-install" instead of "github-backup" in the install instructions.
