### PR TITLE
Fix authentication by using the Authorization header.

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -18,7 +18,7 @@ function get(path) {
 		"Accept": "application/vnd.github.v3+json"
 	};
 	if (accessToken) {
-		options.Authorization = "token " + accessToken;
+		options.headers["Authorization"] = "token " + accessToken;
 	}
 
 	return promisify.httpsGet(options).then(promisify.readableStream).then(JSON.parse);


### PR DESCRIPTION
The private repositories and private organizations didn't work with the current Authorization option. I put it as a separate Authorization header and it worked with that :-)
