### PR TITLE
Use SSH url for cloning to prevent login prompts.

### DIFF
--- a/lib/backup.js
+++ b/lib/backup.js
@@ -6,7 +6,7 @@ var promisify = require("../lib/promisify");
 var path = require("path");
 var fs = Promise.promisifyAll(require("fs"));
 function backupRepo(url, destinationDir) {
-	var re = new RegExp("https://github\\.com/([^/]+)/([^/]+)");
+	var re = new RegExp("git\\@github\\.com:([^/]+)/([^/]+)");
 	var matches = url.match(re);
 	var user = matches[1];
 	var repoName = matches[2];
@@ -41,7 +41,7 @@ function publicUserRepos(username, destinationDir) {
 	return github.getPublicUserRepos(username).then(function(repos) {
 		var promise;
 		for (var i = 0; i < repos.length; i++) {
-			var url = repos[i].clone_url; // jshint ignore:line
+			var url = repos[i].ssh_url; // jshint ignore:line
 			promise = backupRepoSerialized(url, destinationDir, promise);
 		}
 		return promise;


### PR DESCRIPTION
I noticed when backing up private repositories that I get asked for username and password. As github-backup is meant for cronjobs, this is not what I wanted :-) I changed it to use the SSH url because then ssh-agent provides the authentication.

I'm not sure if this is a change for the majority of users, just close it if it creates problems for other cases :-)
